### PR TITLE
style the button more like mbta.com's

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -4,6 +4,7 @@
 const plugin = require("tailwindcss/plugin")
 const fs = require("fs")
 const path = require("path")
+const defaultTheme = require("tailwindcss/defaultTheme");
 
 module.exports = {
   content: [
@@ -14,8 +15,11 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Inter', 'Helvetica Neue', ...defaultTheme.fontFamily.sans],
+      },
       colors: {
-        brand: "#FD4F00",
+        brand: "#165c96",
       }
     },
   },

--- a/lib/blocks/components/button.ex
+++ b/lib/blocks/components/button.ex
@@ -1,13 +1,31 @@
 defmodule Blocks.Components.Button do
-  @moduledoc false
+  @moduledoc """
+  Renders a button.
+
+  ## Examples
+
+    <.button>Send!</.button>
+    <.button phx-click="go" class="ml-2">Send!</.button>
+  """
 
   use Phoenix.Component
+
+  attr :type, :string, default: nil
+  attr :class, :string, default: nil
+  attr :rest, :global, include: ~w(disabled form name value)
 
   slot :inner_block, required: true
 
   def button(assigns) do
     ~H"""
-    <button class="py-3 px-4 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-transparent bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:bg-blue-700 disabled:opacity-50 disabled:pointer-events-none">
+    <button
+      type={@type}
+      class={[
+        "text-base font-normal rounded cursor-pointer inline-block px-4 py-2 text-center select-none align-middle whitespace-nowrap border border-transparent bg-brand text-white",
+        @class
+      ]}
+      {@rest}
+    >
       <%= render_slot(@inner_block) %>
     </button>
     """


### PR DESCRIPTION
I wasn't sure if you'd prefer PRs vs my pushing this in. This
- Adjusts the Tailwind "brand" color to Dotcom's "brand-primary"
- Sets the right font family (will have to figure out actually adding the Inter font later)
- Adjusts the button style to be more like Dotcom's
- Adjusts the button component to the same structure as the one in Phoenix's `CoreComponents`, so we can now configure the button type and add other classes and attributes.