### PR TITLE
fix: Remove limit on values for `type` attribute for `<.icon />` component

### DIFF
--- a/lib/mbta_metro/components/icon.ex
+++ b/lib/mbta_metro/components/icon.ex
@@ -54,7 +54,7 @@ defmodule MbtaMetro.Components.Icon do
 
   attr :class, :string, default: ""
   attr :name, :string, required: true
-  attr :type, :string, default: "solid"
+  attr :type, :string, values: @types, default: "solid"
 
   def icon(assigns) do
     ~H"""

--- a/lib/mbta_metro/components/icon.ex
+++ b/lib/mbta_metro/components/icon.ex
@@ -54,7 +54,7 @@ defmodule MbtaMetro.Components.Icon do
 
   attr :class, :string, default: ""
   attr :name, :string, required: true
-  attr :type, :string, values: ~w[brands regular solid], default: "solid"
+  attr :type, :string, default: "solid"
 
   def icon(assigns) do
     ~H"""


### PR DESCRIPTION
Given that custom icons exist now, an `<.icon />`'s `type` may be something other than `solid`, `regular`, or `brands`.

This removes that limitation, and the associated warning.